### PR TITLE
Command line flags for google_speech options

### DIFF
--- a/modules/mod_google_transcribe/README.md
+++ b/modules/mod_google_transcribe/README.md
@@ -7,8 +7,12 @@ A Freeswitch module that generates real-time transcriptions on a Freeswitch chan
 ### Commands
 The freeswitch module exposes the following API commands:
 
+```bash
+uuid_google_transcribe <uuid> start <lang-code> [interim] [single-utterence](bool) [seperate-recognition](bool) [max-alternatives](int) [profinity-filter](bool) [word-time](bool) [punctuation](bool) [model](string) [enhanced](bool) [hints](word seperated by , and no spaces)
 ```
-uuid_google_transcribe <uuid> start <lang-code> [interim]
+Example:
+```bash
+uuid_google_transcribe a768fc24-992f-4696-aecb-3e9c11409902 start en-US interim true true 5 true true true command_and_search true
 ```
 Attaches media bug to channel and performs streaming recognize request.
 - `uuid` - unique identifier of Freeswitch channel
@@ -20,8 +24,8 @@ uuid_google_transcribe <uuid> stop
 ```
 Stop transcription on the channel.
 
-### Channel Variables
-Additional google speech options can be set through freeswitch channel variables listed below.
+### Command Variables
+Additional google speech options in the command line
 
 | variable | Description |
 | --- | ----------- |

--- a/modules/mod_google_transcribe/README.md
+++ b/modules/mod_google_transcribe/README.md
@@ -6,13 +6,18 @@ A Freeswitch module that generates real-time transcriptions on a Freeswitch chan
 
 ### Commands
 The freeswitch module exposes the following API commands:
+The freeswitch module exposes the following API commands:
+
+```
+uuid_google_transcribe <uuid> start <lang-code> [interim]
+```
 
 ```bash
-uuid_google_transcribe <uuid> start <lang-code> [interim] [single-utterence](bool) [seperate-recognition](bool) [max-alternatives](int) [profinity-filter](bool) [word-time](bool) [punctuation](bool) [model](string) [enhanced](bool) [hints](word seperated by , and no spaces)
+uuid_google_transcribe2 <uuid> start <lang-code> [interim] [single-utterence](bool) [seperate-recognition](bool) [max-alternatives](int) [profinity-filter](bool) [word-time](bool) [punctuation](bool) [model](string) [enhanced](bool) [hints](word seperated by , and no spaces)
 ```
 Example:
 ```bash
-uuid_google_transcribe a768fc24-992f-4696-aecb-3e9c11409902 start en-US interim true true 5 true true true command_and_search true
+uuid_google_transcribe2 a768fc24-992f-4696-aecb-3e9c11409902 start en-US interim true true 5 true true true command_and_search true
 ```
 Attaches media bug to channel and performs streaming recognize request.
 - `uuid` - unique identifier of Freeswitch channel
@@ -25,7 +30,7 @@ uuid_google_transcribe <uuid> stop
 Stop transcription on the channel.
 
 ### Command Variables
-Additional google speech options in the command line
+Additional google speech options can be set through freeswitch channel variables for uuid_google_transcribe and  in the command line for uuid_google_transcribe2
 
 | variable | Description |
 | --- | ----------- |

--- a/modules/mod_google_transcribe/README.md
+++ b/modules/mod_google_transcribe/README.md
@@ -6,7 +6,6 @@ A Freeswitch module that generates real-time transcriptions on a Freeswitch chan
 
 ### Commands
 The freeswitch module exposes the following API commands:
-The freeswitch module exposes the following API commands:
 
 ```
 uuid_google_transcribe <uuid> start <lang-code> [interim]

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -95,7 +95,7 @@ public:
     }
 
     // speech model
-    if (!strcmp(model, "")) {
+    if (model != NULL) {
       config->set_model(model);
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "speech model %s\n", model);
     }
@@ -107,7 +107,7 @@ public:
     }
 
     // hints  
-    if (!strcmp(hints, "")) {
+    if (hints != NULL) {
       char *phrases[500] = { 0 };
       auto *context = config->add_speech_contexts();
       int argc = switch_separate_string((char *) hints, ',', phrases, 500);

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -48,12 +48,15 @@ public:
 
     streaming_config->set_interim_results(interim);
     if (single_utterence == 1) {
-      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "single_utterance\n");
+      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enable_single_utterance\n");
       streaming_config->set_single_utterance(true);
     }
 
 		config->set_language_code(lang);
-  	config->set_sample_rate_hertz(16000);
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "transcribe language %s \n", lang);
+    int sample_rate = switch_channel_get_variable(channel, "read_rate");
+  	config->set_sample_rate_hertz(sample_rate);
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "sample rate %s \n", sample_rate);
 		config->set_encoding(RecognitionConfig::LINEAR16);
 
     // the rest of config comes from channel vars

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -120,6 +120,20 @@ public:
 
   	// Write the first request, containing the config only.
   	m_streamer->Write(m_request);
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_NOTICE, "------------ Transcribe Config------------ \n");
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "interim_results %d \n", interim);
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "single_utterance %d \n", streaming_config->single_utterance());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "sample_rate_hertz %d \n", config->sample_rate_hertz());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "audio_channel_count %d \n", config->audio_channel_count());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enable_separate_recognition_per_channel %d \n", config->enable_separate_recognition_per_channel());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "language_code %s \n", lang);
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "max_alternatives %d \n", config->max_alternatives());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "profanity_filter %d \n", config->profanity_filter());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enable_word_time_offsets %d \n", config->enable_word_time_offsets());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enable_automatic_punctuation %d \n", config->enable_automatic_punctuation());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "model %s \n", config->model());
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "use_enhanced %d \n", config->use_enhanced());
+
 	}
 
 	~GStreamer() {
@@ -167,13 +181,20 @@ private:
 };
 
 static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *obj) {
+  static int count;
 	struct cap_cb *cb = (struct cap_cb *) obj;
 	GStreamer* streamer = (GStreamer *) cb->streamer;
 
   // Read responses.
   StreamingRecognizeResponse response;
   while (streamer->read(&response)) {  // Returns false when no more to read.
+    count++;
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "response counter:  %d\n",count) ;̥
     auto speech_event_type = response.speech_event_type();
+    Status st = response.error();
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "-----------Response-----------" );
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "speech_event_type: %d \n", response.speech_event_type()) ;
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "grpc_read_thread: error %s code: (%d)\n", st.message().c_str(), st.code()) ;
     if (response.has_error()) {
       Status status = response.error();
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "grpc_read_thread: error %s (%d)\n", status.message().c_str(), status.code()) ;

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -22,7 +22,7 @@ class GStreamer;
 
 class GStreamer {
 public:
-	GStreamer(switch_core_session_t *session, u_int16_t channels, char* lang, int interim) : 
+	GStreamer(switch_core_session_t *session, u_int16_t channels, char* lang, int interim, int utterence) : 
     m_session(session), m_writesDone(false) {
     const char* var;
     const char *hints;
@@ -45,7 +45,7 @@ public:
 		RecognitionConfig* config = streaming_config->mutable_config();
 
     streaming_config->set_interim_results(interim);
-    if (switch_true(switch_channel_get_variable(channel, "GOOGLE_SPEECH_SINGLE_UTTERANCE"))) {
+    if (utterence == 1) {
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "single_utterance\n");
       streaming_config->set_single_utterance(true);
     }
@@ -303,7 +303,7 @@ extern "C" {
       return SWITCH_STATUS_SUCCESS;
     }
     switch_status_t google_speech_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
-          uint32_t samples_per_second, uint32_t channels, char* lang, int interim, void **ppUserData) {
+          uint32_t samples_per_second, uint32_t channels, char* lang, int interim, int utterence, void **ppUserData) {
 
       switch_channel_t *channel = switch_core_session_get_channel(session);
       struct cap_cb *cb;
@@ -328,7 +328,7 @@ extern "C" {
 
       GStreamer *streamer = NULL;
       try {
-        streamer = new GStreamer(session, channels, lang, interim);
+        streamer = new GStreamer(session, channels, lang, interim,utterence );
         cb->streamer = streamer;
       } catch (std::exception& e) {
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing gstreamer: %s.\n", 

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -28,7 +28,6 @@ public:
 
     m_session(session), m_writesDone(false) {
     const char* var;
-    const char *hints;
     switch_channel_t *channel = switch_core_session_get_channel(session);
 
 		if (var = switch_channel_get_variable(channel, "GOOGLE_APPLICATION_CREDENTIALS")) {
@@ -74,7 +73,7 @@ public:
     // max alternatives
     if (max_alternatives > 1) {
       config->set_max_alternatives(max_alternatives);
-      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "max_alternatives %d\n", max_alternatives;
+      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "max_alternatives %d\n", max_alternatives);
     }
 
     // profanity filter
@@ -90,7 +89,7 @@ public:
     }
 
     // enable automatic punctuation
-    if (punctuation == 1)) {
+    if (punctuation == 1) {
       config->set_enable_automatic_punctuation(true);
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enable_automatic_punctuation\n");
     }

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -22,7 +22,7 @@ class GStreamer;
 
 class GStreamer {
 public:
-	GStreamer(switch_core_session_t *session, u_int16_t channels, char* lang, int interim, int single_utterence, int sepreate_recognition,
+	GStreamer(switch_core_session_t *session, u_int16_t channels, char* lang, int interim, int single_utterence, int separate_recognition,
 		int max_alternatives, int profinity_filter, int word_time_offset, int punctuation, char* model, int enhanced, 
 		char* hints) : 
 
@@ -53,8 +53,8 @@ public:
     }
 
 		config->set_language_code(lang);
-
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "transcribe language %s \n", lang);
+    
     int sample_rate = atoi(switch_channel_get_variable(channel, "read_rate"));
   	config->set_sample_rate_hertz(sample_rate);
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "sample rate %d \n", sample_rate);
@@ -69,7 +69,7 @@ public:
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "audio_channel_count %d\n", channels);
 
       // transcribe each separately?
-      if (sepreate_recognition == 1) {
+      if (separate_recognition == 1) {
         config->set_enable_separate_recognition_per_channel(true);
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enable_separate_recognition_per_channel on\n");
       }
@@ -296,7 +296,7 @@ extern "C" {
     }
     switch_status_t google_speech_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
           uint32_t samples_per_second, uint32_t channels, char* lang, int interim, int single_utterence,
-          int sepreate_recognition, int max_alternatives, int profinity_filter, int word_time_offset,
+          int separate_recognition, int max_alternatives, int profinity_filter, int word_time_offset,
           int punctuation, char* model, int enhanced, char* hints, void **ppUserData) {
 
       switch_channel_t *channel = switch_core_session_get_channel(session);
@@ -311,7 +311,7 @@ extern "C" {
 
       GStreamer *streamer = NULL;
       try {
-        streamer = new GStreamer(session, channels, lang, interim, single_utterence, sepreate_recognition, max_alternatives,
+        streamer = new GStreamer(session, channels, lang, interim, single_utterence, separate_recognition, max_alternatives,
          profinity_filter, word_time_offset, punctuation, model, enhanced, hints);
         cb->streamer = streamer;
       } catch (std::exception& e) {

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -189,7 +189,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
   StreamingRecognizeResponse response;
   while (streamer->read(&response)) {  // Returns false when no more to read.
     count++;
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "response counter:  %d\n",count) ;̥
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "response counter:  %d\n",count) ;
     auto speech_event_type = response.speech_event_type();
     Status st = response.error();
     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "-----------Response-----------" );

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -54,9 +54,9 @@ public:
 
 		config->set_language_code(lang);
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "transcribe language %s \n", lang);
-    int sample_rate = switch_channel_get_variable(channel, "read_rate");
+    int sample_rate = atoi(switch_channel_get_variable(channel, "read_rate"));
   	config->set_sample_rate_hertz(sample_rate);
-    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "sample rate %s \n", sample_rate);
+    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "sample rate %d \n", sample_rate);
 		config->set_encoding(RecognitionConfig::LINEAR16);
 
     // the rest of config comes from channel vars
@@ -307,16 +307,6 @@ extern "C" {
 
       switch_mutex_init(&cb->mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 
-      if (samples_per_second != 16000) {
-          cb->resampler = speex_resampler_init(channels, samples_per_second, 16000, SWITCH_RESAMPLE_QUALITY, &err);
-        if (0 != err) {
-           switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing resampler: %s.\n",
-                                 switch_channel_get_name(channel), speex_resampler_strerror(err));
-          return SWITCH_STATUS_FALSE;
-        }
-      } else {
-        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%s: no resampling needed for this call\n", switch_channel_get_name(channel));
-      }
 
       GStreamer *streamer = NULL;
       try {

--- a/modules/mod_google_transcribe/google_glue.h
+++ b/modules/mod_google_transcribe/google_glue.h
@@ -4,7 +4,7 @@
 switch_status_t google_speech_init();
 switch_status_t google_speech_cleanup();
 switch_status_t google_speech_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
-		uint32_t samples_per_second, uint32_t channels, char* lang, int interim, void **ppUserData);
+		uint32_t samples_per_second, uint32_t channels, char* lang, int interim,int utterence , void **ppUserData);
 switch_status_t google_speech_session_cleanup(switch_core_session_t *session, int channelIsClosing);
 switch_bool_t google_speech_frame(switch_media_bug_t *bug, void* user_data);
 

--- a/modules/mod_google_transcribe/google_glue.h
+++ b/modules/mod_google_transcribe/google_glue.h
@@ -4,7 +4,9 @@
 switch_status_t google_speech_init();
 switch_status_t google_speech_cleanup();
 switch_status_t google_speech_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
-		uint32_t samples_per_second, uint32_t channels, char* lang, int interim,int utterence , void **ppUserData);
+		uint32_t samples_per_second, uint32_t channels, char* lang, int interim, int single_utterence, int sepreate_recognition,
+		int max_alternatives, int profinity_filter, int word_time_offset, int punctuation, char* model, int enhanced, 
+		char* hints, void **ppUserData);
 switch_status_t google_speech_session_cleanup(switch_core_session_t *session, int channelIsClosing);
 switch_bool_t google_speech_frame(switch_media_bug_t *bug, void* user_data);
 

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -146,7 +146,9 @@ SWITCH_STANDARD_API(transcribe_function)
 {
 	char *mycmd = NULL, *argv[20] = { 0 };
 	int argc = 0;
-	char *hints;
+	char* hints = NULL, model = NULL;
+	int enhanced;
+	
 	switch_status_t status = SWITCH_STATUS_FALSE;
 	switch_media_bug_flag_t flags = SMBF_READ_STREAM /* | SMBF_WRITE_STREAM | SMBF_READ_PING */;
 
@@ -178,8 +180,10 @@ SWITCH_STANDARD_API(transcribe_function)
 		int profinity_filter = !strcmp(argv[7], "true"); // profinity-filter
 		int word_time_offset = !strcmp(argv[8], "true"); // word-time
 		int punctuation      = !strcmp(argv[9], "true");  //punctuation
-		char* model = argv[10]; // model 
-		int enhanced = !strcmp(argv[11], "true"); // enhanced
+		if (argc > 9){
+			model = argv[10]; // model 
+			enhanced = !strcmp(argv[11], "true"); // enhanced
+		}
 		if (argc > 11){
 			hints = argv[12]; // hints
 		}

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -126,7 +126,7 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 
 	samples_per_second = !strcasecmp(read_impl.iananame, "g722") ? read_impl.actual_samples_per_second : read_impl.samples_per_second;
 
-	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, &pUserData)) {
+	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, utterence &pUserData)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error initializing google speech session.\n");
 		return SWITCH_STATUS_FALSE;
 	}
@@ -139,10 +139,10 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 }
 
 // #define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim] [single-utterence] [seperate recognition] [max-alternatives] [profinity-filter] [word-time] [punctuation] [model] [enhanced] [hints]"
-#define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim] [single-utterence] 
+#define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim] [single-utterence]"
 SWITCH_STANDARD_API(transcribe_function)
 {
-	char *mycmd = NULL, *argv[10] = { 0 }, *;
+	char *mycmd = NULL, *argv[10] = { 0 };
 	int argc = 0;
 	switch_status_t status = SWITCH_STATUS_FALSE;
 	switch_media_bug_flag_t flags = SMBF_READ_STREAM /* | SMBF_WRITE_STREAM | SMBF_READ_PING */;

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -146,6 +146,7 @@ SWITCH_STANDARD_API(transcribe_function)
 {
 	char *mycmd = NULL, *argv[20] = { 0 };
 	int argc = 0;
+	char *hints;
 	switch_status_t status = SWITCH_STATUS_FALSE;
 	switch_media_bug_flag_t flags = SMBF_READ_STREAM /* | SMBF_WRITE_STREAM | SMBF_READ_PING */;
 
@@ -155,7 +156,7 @@ SWITCH_STANDARD_API(transcribe_function)
 
 	if (zstr(cmd) || 
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
-      (!strcasecmp(argv[1], "start") && argc < 3) ||
+      (!strcasecmp(argv[1], "start") && argc < 11) ||
       zstr(argv[0])) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE_API_SYNTAX);
@@ -179,8 +180,9 @@ SWITCH_STANDARD_API(transcribe_function)
 		int punctuation      = !strcmp(argv[9], "true");  //punctuation
 		char* model = argv[10]; // model 
 		int enhanced = !strcmp(argv[11], "true"); // enhanced
-		char* hints = argv[12]; // hints
-		
+		if (argc > 11){
+			hints = argv[12]; // hints
+		}
     		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s\n", lang, interim ? "interim": "complete");
 				status = start_capture(lsession, flags, lang, interim, single_utterence, sepreate_recognition,max_alternatives,
 				profinity_filter, word_time_offset, punctuation, model, enhanced, hints);

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -104,7 +104,7 @@ static switch_status_t do_stop(switch_core_session_t *session)
 }
 
 static switch_status_t start_capture(switch_core_session_t *session, switch_media_bug_flag_t flags, 
-  char* lang, int interim)
+  char* lang, int interim, int utterence)
 {
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	switch_media_bug_t *bug;
@@ -138,10 +138,11 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 	return SWITCH_STATUS_SUCCESS;
 }
 
-#define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim]"
+// #define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim] [single-utterence] [seperate recognition] [max-alternatives] [profinity-filter] [word-time] [punctuation] [model] [enhanced] [hints]"
+#define TRANSCRIBE_API_SYNTAX "<uuid> [start|stop] [lang-code] [interim] [single-utterence] 
 SWITCH_STANDARD_API(transcribe_function)
 {
-	char *mycmd = NULL, *argv[5] = { 0 };
+	char *mycmd = NULL, *argv[10] = { 0 }, *;
 	int argc = 0;
 	switch_status_t status = SWITCH_STATUS_FALSE;
 	switch_media_bug_flag_t flags = SMBF_READ_STREAM /* | SMBF_WRITE_STREAM | SMBF_READ_PING */;
@@ -167,8 +168,9 @@ SWITCH_STANDARD_API(transcribe_function)
 			} else if (!strcasecmp(argv[1], "start")) {
         char* lang = argv[2];
         int interim = argc > 3 && !strcmp(argv[3], "interim");
+		int utterence = argc > 4 && !strcmp(argv[4], "single-utterence");
     		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s\n", lang, interim ? "interim": "complete");
-				status = start_capture(lsession, flags, lang, interim);
+				status = start_capture(lsession, flags, lang, interim,utterence);
 			}
 			switch_core_session_rwunlock(lsession);
 		}

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -145,9 +145,9 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 SWITCH_STANDARD_API(transcribe_function)
 {
 	char *mycmd = NULL, *argv[20] = { 0 };
-	int argc = 0;
-	char* hints = NULL, model = NULL;
-	int enhanced;
+	int argc = 0, enhanced = 0;
+	char* hints = NULL;
+	char* model = NULL;
 	
 	switch_status_t status = SWITCH_STATUS_FALSE;
 	switch_media_bug_flag_t flags = SMBF_READ_STREAM /* | SMBF_WRITE_STREAM | SMBF_READ_PING */;

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -174,12 +174,12 @@ SWITCH_STANDARD_API(transcribe_function)
 		int single_utterence =  !strcmp(argv[4], "true"); // single-utterence
 		int sepreate_recognition = !strcmp(argv[5], "true"); // sepreate-recognition
 		int max_alternatives = atoi(argv[6]); // max-alternatives
-		int profinity_filter = !strcmp(argv[6], "true"); // profinity-filter
-		int word_time_offset = !strcmp(argv[7], "true"); // word-time
-		int punctuation      = !strcmp(argv[8], "true");  //punctuation
-		char* model = argv[9]; // model 
-		int enhanced = !strcmp(argv[10], "true"); // enhanced
-		char* hints = argv[11]; // hints
+		int profinity_filter = !strcmp(argv[7], "true"); // profinity-filter
+		int word_time_offset = !strcmp(argv[8], "true"); // word-time
+		int punctuation      = !strcmp(argv[9], "true");  //punctuation
+		char* model = argv[10]; // model 
+		int enhanced = !strcmp(argv[11], "true"); // enhanced
+		char* hints = argv[12]; // hints
 		
     		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s\n", lang, interim ? "interim": "complete");
 				status = start_capture(lsession, flags, lang, interim, single_utterence, sepreate_recognition,max_alternatives,

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -158,7 +158,7 @@ SWITCH_STANDARD_API(transcribe_function)
 
 	if (zstr(cmd) || 
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
-      (!strcasecmp(argv[1], "start") && argc < 11) ||
+      (!strcasecmp(argv[1], "start") && argc < 9) ||
       zstr(argv[0])) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE_API_SYNTAX);


### PR DESCRIPTION
- Now, there is no need to set a channel variable for google_speech_option.

- New Command: 

```bash
uuid_google_transcribe <uuid> start <lang-code> [interim] [single-utterence](bool) [seperate-recognition](bool) [max-alternatives](int) [profinity-filter](bool) [word-time](bool) [punctuation](bool) [model](string) [enhanced](bool) [hints](word seperated by , and no spaces)
```
Example:
```bash
uuid_google_transcribe a768fc24-992f-4696-aecb-3e9c11409902 start en-US interim true true 5 true true true command_and_search true yes,no,hello
```

- Also now sample_rate is dynamic for each call
- Logging also added
![image](https://user-images.githubusercontent.com/59245804/100338441-94d33380-2ffe-11eb-8b75-f6685109714f.png)

