### PR TITLE
TX-549 | Audio fork changes 

### DIFF
--- a/modules/mod_audio_fork/README.md
+++ b/modules/mod_audio_fork/README.md
@@ -1,64 +1,99 @@
 # mod_audio_fork
 
-A Freeswitch module that attaches a bug to a media server endpoint and streams L16 audio via websockets to a remote server.  This module also supports receiving media from the server to play back to the caller, enabling the creation of full-fledged IVR or dialog-type applications.
+A Freeswitch module that attaches a bug to a media server endpoint and streams L16 audio via websockets to a remote
+server. This module also supports receiving media from the server to play back to the caller, enabling the creation of
+full-fledged IVR or dialog-type applications.
 
 #### Environment variables
-- MOD_AUDIO_FORK_SUBPROTOCOL_NAME - optional, name of the [websocket sub-protocol](https://tools.ietf.org/html/rfc6455#section-1.9) to advertise; defaults to "audio.drachtio.org"
-- MOD_AUDIO_FORK_SERVICE_THREADS - optional, number of libwebsocket service threads to create; these threads handling sending all messages for all sessions.  Defaults to 1, but can be set to as many as 5.
+
+- MOD_AUDIO_FORK_SUBPROTOCOL_NAME - optional, name of
+  the [websocket sub-protocol](https://tools.ietf.org/html/rfc6455#section-1.9) to advertise; defaults to "
+  audio.drachtio.org"
+- MOD_AUDIO_FORK_SERVICE_THREADS - optional, number of libwebsocket service threads to create; these threads handling
+  sending all messages for all sessions. Defaults to 1, but can be set to as many as 5.
 
 ## API
 
 ### Commands
+
 The freeswitch module exposes the following API commands:
 
 ```
-uuid_audio_fork <uuid> start <wss-url> <mix-type> <sampling-rate> <metadata>
+uuid_audio_fork <uuid> start <wss-url> <mix-type> <sampling-rate> <streamID> <accID> <uuidWithHash> <track> <metadata>
 ```
-Attaches media bug and starts streaming audio stream to the back-end server.  Audio is streamed in linear 16 format (16-bit PCM encoding) with either one or two channels depending on the mix-type requested.
+
+Attaches media bug and starts streaming audio stream to the back-end server. Audio is streamed in linear 16 format (
+16-bit PCM encoding) with either one or two channels depending on the mix-type requested.
+
 - `uuid` - unique identifier of Freeswitch channel
 - `wss-url` - websocket url to connect and stream audio to
-- `mix-type` - choice of 
-  - "mono" - single channel containing caller's audio
-  - "mixed" - single channel containing both caller and callee audio
-  - "stereo" - two channels with caller audio in one and callee audio in the other.
+- `mix-type` - choice of
+    - "mono" - single channel containing caller's audio
+    - "mixed" - single channel containing both caller and callee audio
+    - "stereo" - two channels with caller audio in one and callee audio in the other.
 - `sampling-rate` - choice of
-  - "8k" = 8000 Hz sample rate will be generated
-  - "16k" = 16000 Hz sample rate will be generated
-- `metadata` - a text frame of arbitrary data to send to the back-end server immediately upon connecting.  Once this text frame has been sent, the incoming audio will be sent in binary frames to the server.
+    - "8k" = 8000 Hz sample rate will be generated
+    - "16k" = 16000 Hz sample rate will be generated
+- `streamId` - unique streaming id
+- `accID` - accID of the call leg
+- `uuidWithHash` - custom uuid with CID
+- `track` - call track to stream (`experimental`)
+    - "both_tracks" = both inbound and outbound track
+    - "inbound_track" = only inbound track
+    - "outbound_track" = only outbound track
+- `metadata` - a text frame of arbitrary data to send to the back-end server immediately upon connecting. Once this text
+  frame has been sent, the incoming audio will be sent in binary frames to the server.
 
 ```
 uuid_audio_fork <uuid> send_text <metadata>
 ```
+
 Send a text frame of arbitrary data to the remote server (e.g. this can be used to notify of DTMF events).
 
 ```
 uuid_audio_fork <uuid> stop <metadata>
 ```
-Closes websocket connection and detaches media bug, optionally sending a final text frame over the websocket connection before closing.
+
+Closes websocket connection and detaches media bug, optionally sending a final text frame over the websocket connection
+before closing.
 
 ### Events
-An optional feature of this module is that it can receive JSON text frames from the server and generate associated events to an application.  The format of the JSON text frames and the associated events are described below.
+
+An optional feature of this module is that it can receive JSON text frames from the server and generate associated
+events to an application. The format of the JSON text frames and the associated events are described below.
 
 #### audio
+
 ##### server JSON message
+
 The server can provide audio content to be played back to the caller by sending a JSON text frame like this:
+
 ```json
-{
-	"type": "playAudio",
-	"data": {
-		"audioContentType": "raw",
-		"sampleRate": 8000,
-		"audioContent": "base64 encoded raw audio..",
-		"textContent": "Hi there!  How can we help?"
-	}
+      {
+  "streamSid": "1ba96f40-8317-11eb-a897-12964972f583",
+  "event": "media",
+  "media": {
+    "audioContentType": "raw",
+    "sampleRate": 8000,
+    "payload": "base64 encoded raw audio..",
+    "textContent": "Hi there!  How can we help?"
+  }
 }
 ```
-The `audioContentType` value can be either `wave` or `raw`.  If the latter, then `sampleRate` must be specified.  The audio content itself is supplied as a base64 encoded string.  The `textContent` attribute can optionally contain the text of the prompt.  This allows an application to choose whether to play the raw audio or to use its own text-to-speech to play the text prompt.
 
-Note that the module does _not_ directly play out the raw audio.  Instead, it writes it to a temporary file and provides the path to the file in the event generated.  It is left to the application to play out this file if it wishes to do so.
+The `audioContentType` value can be either `wave` or `raw`. If the latter, then `sampleRate` must be specified. The
+audio content itself is supplied as a base64 encoded string. The `textContent` attribute can optionally contain the text
+of the prompt. This allows an application to choose whether to play the raw audio or to use its own text-to-speech to
+play the text prompt.
+
+Note that the module does _not_ directly play out the raw audio. Instead, it writes it to a temporary file and provides
+the path to the file in the event generated. It is left to the application to play out this file if it wishes to do so.
+
 ##### Freeswitch event generated
+
 **Name**: mod_audio_fork::play_audio
 **Body**: JSON string
+
 ```
 {
   "audioContentType": "raw",
@@ -67,121 +102,176 @@ Note that the module does _not_ directly play out the raw audio.  Instead, it wr
   "file": "/tmp/7dd5e34e-5db4-4edb-a166-757e5d29b941_2.tmp.r8"
 }
 ```
-Note the audioContent attribute has been replaced with the path to the file containing the audio.  This temporary file will be removed when the Freeswitch session ends.
+
+Note the audioContent attribute has been replaced with the path to the file containing the audio. This temporary file
+will be removed when the Freeswitch session ends.
+
 #### killAudio
+
 ##### server JSON message
+
 The server can provide a request to kill the current audio playback:
+
 ```json
+
 {
-	"type": "killAudio",
+  "streamSid": "1ba96f40-8317-11eb-a897-12964972f583",
+  "event": "killAudio"
 }
+
 ```
-Any current audio being played to the caller will be immediately stopped.  The event sent to the application is for information purposes only.
+
+Any current audio being played to the caller will be immediately stopped. The event sent to the application is for
+information purposes only.
 
 ##### Freeswitch event generated
+
 **Name**: mod_audio_fork::kill_audio
 **Body**: JSON string - the data attribute from the server message
 
-
 #### transcription
+
 ##### server JSON message
+
 The server can optionally provide transcriptions to the application in real-time:
+
 ```json
 {
-	"type": "transcription",
-	"data": {
-    
-	}
+  "streamSid": "1ba96f40-8317-11eb-a897-12964972f583",
+  "event": "transcription",
+  "data": {
+  }
 }
 ```
-The transcription data can be any JSON object; for instance, a server may choose to return a transcript and an associated confidence level.  Whatever is provided as the `data` attribute will be attached to the generated event.
+
+The transcription data can be any JSON object; for instance, a server may choose to return a transcript and an
+associated confidence level. Whatever is provided as the `data` attribute will be attached to the generated event.
 
 ##### Freeswitch event generated
+
 **Name**: mod_audio_fork::transcription
 **Body**: JSON string - the data attribute from the server message
 
 #### transfer
+
 ##### server JSON message
+
 The server can optionally provide a request to transfer the call:
+
 ```json
 {
-	"type": "transfer",
-	"data": {
-    
-	}
+  "streamSid":"1ba96f40-8317-11eb-a897-12964972f583",
+  "event": "transfer",
+  "data": {
+  }
 }
 ```
-The transfer data can be any JSON object and is left for the application to determine how to handle it and accomplish the call transfer.  Whatever is provided as the `data` attribute will be attached to the generated event.
+
+The transfer data can be any JSON object and is left for the application to determine how to handle it and accomplish
+the call transfer. Whatever is provided as the `data` attribute will be attached to the generated event.
 
 ##### Freeswitch event generated
+
 **Name**: mod_audio_fork::transfer
 **Body**: JSON string - the data attribute from the server message
 
 #### disconnect
+
 ##### server JSON message
+
 The server can optionally request to disconnect the caller:
+
 ```json
 {
-	"type": "disconnect"
+  "streamSid":"1ba96f40-8317-11eb-a897-12964972f583",
+  "event": "disconnect"
 }
 ```
-Note that the module _does not_ close the Freeswitch channel when a disconnect request is received.  It is left for the application to determine whether to tear down the call.
+
+Note that the module _does not_ close the Freeswitch channel when a disconnect request is received. It is left for the
+application to determine whether to tear down the call.
 
 ##### Freeswitch event generated
+
 **Name**: mod_audio_fork::disconnect
 **Body**: none
 
 #### error
+
 ##### server JSON message
-The server can optionally report an error of some kind.  
+
+The server can optionally report an error of some kind.
+
 ```json
 {
-	"type": "error",
-	"data": {
-    
-	}
+  "streamSid":"1ba96f40-8317-11eb-a897-12964972f583",
+  "event": "error",
+  "data": {
+  }
 }
 ```
-The error data can be any JSON object and is left for the application to the application to determine what, if any, action should be taken in response to an error..  Whatever is provided as the `data` attribute will be attached to the generated event.
+
+The error data can be any JSON object and is left for the application to the application to determine what, if any,
+action should be taken in response to an error.. Whatever is provided as the `data` attribute will be attached to the
+generated event.
 
 ##### Freeswitch event generated
+
 **Name**: mod_audio_fork::error
 **Body**: JSON string - the data attribute from the server message
 
 ## Usage
-When using [drachtio-fsrmf](https://www.npmjs.com/package/drachtio-fsmrf), you can access this API command via the api method on the 'endpoint' object.
+
+When using [drachtio-fsrmf](https://www.npmjs.com/package/drachtio-fsmrf), you can access this API command via the api
+method on the 'endpoint' object.
+
 ```js
 const url = 'https://70f21a76.ngrok.io';
 const callerData = {to: '6173333456', from: '2061236666', callid: req.get('Call-Id')};
 ep.api('uuid_audio_fork', `${ep.uuid} start ${url} mono 8k ${JSON.stringify(callerData)}`);
 ```
+
 or, from version 1.4.1 on, by using the Endpoint convenience methods:
+
 ```js
 await ep.forkAudioStart({
-  wsUrl,
-  mixType: 'stereo',
-  sampling: '16k',
-  metadata
+    wsUrl,
+    mixType: 'stereo',
+    sampling: '16k',
+    metadata
 });
 ..
 ep.forkAudioSendText(moremetadata);
 ..
 ep.forkAudioStop(evenmoremetadata);
 ```
-Each of the methods above returns a promise that resolves when the api command has been executed, or throws an error.
-## Examples
-[audio_fork.js](../../examples/audio_fork.js) provides an example of an application that connects an incoming call to Freeswitch and then forks the audio to a remote websocket server.
 
-To run this app, you can run [the simple websocket server provided](../../examples/ws_server.js) in a separate terminal.  It will listen on port 3001 and will simply write the incoming raw audio to `/tmp/audio.raw` in linear16 format with no header or file container.
+Each of the methods above returns a promise that resolves when the api command has been executed, or throws an error.
+
+## Examples
+
+[audio_fork.js](../../examples/audio_fork.js) provides an example of an application that connects an incoming call to
+Freeswitch and then forks the audio to a remote websocket server.
+
+To run this app, you can run [the simple websocket server provided](../../examples/ws_server.js) in a separate terminal.
+It will listen on port 3001 and will simply write the incoming raw audio to `/tmp/audio.raw` in linear16 format with no
+header or file container.
 
 So in the first terminal window run:
+
 ```
 node ws_server.js
 ```
+
 And in the second window run:
+
 ```
 node audio_fork.js http://localhost:3001
 ```
-The app uses text-to-speech to play prompts, so you will need mod_google_tts loaded as well, and configured to use your GCS cloud credentials to access Google Cloud Text-to-Speech.  (If you don't want to run mod_google_tts you can of course simply modify the application remove the prompt, just be aware that you will hear silence when you connect, and should simply begin speaking after the call connects).
+
+The app uses text-to-speech to play prompts, so you will need mod_google_tts loaded as well, and configured to use your
+GCS cloud credentials to access Google Cloud Text-to-Speech.  (If you don't want to run mod_google_tts you can of course
+simply modify the application remove the prompt, just be aware that you will hear silence when you connect, and should
+simply begin speaking after the call connects).
 
 

--- a/modules/mod_audio_fork/README.md
+++ b/modules/mod_audio_fork/README.md
@@ -19,7 +19,7 @@ full-fledged IVR or dialog-type applications.
 The freeswitch module exposes the following API commands:
 
 ```
-uuid_audio_fork <uuid> start <wss-url> <mix-type> <sampling-rate> <streamID> <accID> <uuidWithHash> <track> <metadata>
+uuid_audio_fork <uuid> start <wss-url> <mix-type> <sampling-rate> <streamID> <accID> <callSid> <track> <metadata>
 ```
 
 Attaches media bug and starts streaming audio stream to the back-end server. Audio is streamed in linear 16 format (
@@ -36,7 +36,7 @@ Attaches media bug and starts streaming audio stream to the back-end server. Aud
     - "16k" = 16000 Hz sample rate will be generated
 - `streamId` - unique streaming id
 - `accID` - accID of the call leg
-- `uuidWithHash` - custom uuid with CID
+- `callSid` - custom uuid with CID
 - `track` - call track to stream (`experimental`)
     - "both_tracks" = both inbound and outbound track
     - "inbound_track" = only inbound track

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -165,7 +165,9 @@ namespace {
         free(jsonString);
       }
       else if (0 == event.compare("mark")){
-          // mark event
+          char* jsonString = cJSON_PrintUnformatted(json);
+          tech_pvt->responseHandler(session, EVENT_MARK, jsonString);
+          free(jsonString);
       }
       else if (0 == event.compare("clear")){
           // clear event

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -164,6 +164,12 @@ namespace {
         tech_pvt->responseHandler(session, EVENT_JSON, jsonString);
         free(jsonString);
       }
+      else if (0 == event.compare("mark")){
+          // mark event
+      }
+      else if (0 == event.compare("clear")){
+          // clear event
+      }
       else {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "(%u) processIncomingMessage - unsupported msg type %s\n", tech_pvt->id, event.c_str());
       }

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -265,12 +265,18 @@ SWITCH_STANDARD_API(fork_function)
             }
             cJSON_AddItemToObject(start, "tracks", tracks);
             if(track){
-                cJSON_AddItemToArray(tracks, cJSON_CreateString(track));
-                if (0 == strcmp(track, "both")){
+                if (0 == strcmp(track, "both_tracks")){
                     channel = 2;
+                    cJSON_AddItemToArray(tracks, cJSON_CreateString("inbound"));
+                    cJSON_AddItemToArray(tracks, cJSON_CreateString("outbound"));
                 }
-                else{
+                else if (0 == strcmp(track, "outbound_track"){
                     channel = 1;
+                    cJSON_AddItemToArray(tracks, cJSON_CreateString("outbound"));
+                }
+                else {
+                    channel = 1;
+                    cJSON_AddItemToArray(tracks, cJSON_CreateString("inbound"));
                 }
             }
             cJSON_AddItemToObject(start, "mediaFormat", mediaFormat);

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -153,10 +153,10 @@ static switch_status_t send_text(switch_core_session_t *session, char* text) {
   return status;
 }
 
-#define FORK_API_SYNTAX "<uuid> [start | stop | send_text | pause | resume | graceful-shutdown ] [wss-url | path] [mono | mixed | stereo] [8000 | 16000 | 24000 | 32000 | 64000] [streamID] [accID] [uuid_with_cid] [metadata]"
+#define FORK_API_SYNTAX "<uuid> [start | stop | send_text | pause | resume | graceful-shutdown ] [wss-url | path] [mono | mixed | stereo] [8000 | 16000 | 24000 | 32000 | 64000] [streamID] [accID] [uuidWithHash] [track] [metadata]"
 SWITCH_STANDARD_API(fork_function)
 {
-	char *mycmd = NULL, *argv[9] = { 0 };
+	char *mycmd = NULL, *argv[10] = { 0 };
 	int argc = 0;
 	switch_status_t status = SWITCH_STATUS_FALSE;
 
@@ -202,11 +202,13 @@ SWITCH_STANDARD_API(fork_function)
         unsigned int port;
         int sslFlags;
         int sampling = 8000;
+        int channel = 1;
       	switch_media_bug_flag_t flags = SMBF_READ_STREAM ;
       	char *streamID = argc > 5 ? argv[5] : NULL ;
       	char *accID = argc > 6 ? argv[6] : NULL ;
       	char *uuidWithCID = argc > 7 ? argv[7]: NULL;
-        char *metadata = argc > 8 ? argv[8] : NULL ;
+        char *track = argc > 8 ? argv[8] : NULL ;
+        char *metadata = argc > 9 ? argv[9] : NULL ;
         if (0 == strcmp(argv[3], "mixed")) {
           flags |= SMBF_WRITE_STREAM ;
         }
@@ -262,10 +264,18 @@ SWITCH_STANDARD_API(fork_function)
                 cJSON_AddItemToObject(start, "customParameters", custom);
             }
             cJSON_AddItemToObject(start, "tracks", tracks);
-            cJSON_AddItemToArray(tracks, cJSON_CreateString("inbound"));
+            if(track){
+                cJSON_AddItemToArray(tracks, cJSON_CreateString(track));
+                if (0 == strcmp(track, "both")){
+                    channel = 2;
+                }
+                else{
+                    channel = 1;
+                }
+            }
             cJSON_AddItemToObject(start, "mediaFormat", mediaFormat);
             cJSON_AddItemToObject(mediaFormat, "sampleRate", cJSON_CreateNumber(sampling));
-            cJSON_AddItemToObject(mediaFormat, "channel", cJSON_CreateNumber(1));
+            cJSON_AddItemToObject(mediaFormat, "channel", cJSON_CreateNumber(channel));
             cJSON_AddItemToObject(mediaFormat, "encoding", cJSON_CreateString("audio/x-mulaw"));
             out = cJSON_Print(obj);
 

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -270,10 +270,10 @@ SWITCH_STANDARD_API(fork_function)
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("inbound"));
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("outbound"));
                 }
-                else if (0 == strcmp(track, "outbound_track"){
+                else if (0 == strcmp(track, "outbound_track")){
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("outbound"));
                 }
-                else if (0 == strcmp(track, "inbound_track"){
+                else if (0 == strcmp(track, "inbound_track")){
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("inbound"));
                 }
                 else{

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -197,7 +197,7 @@ SWITCH_STANDARD_API(fork_function)
         status = send_text(lsession, argv[2]);
       }
       else if (!strcasecmp(argv[1], "start")) {
-				switch_channel_t *channel = switch_core_session_get_channel(lsession);
+        switch_channel_t *channel = switch_core_session_get_channel(lsession);
         char host[MAX_WS_URL_LEN], path[MAX_PATH_LEN];
         unsigned int port;
         int sslFlags;
@@ -228,15 +228,15 @@ SWITCH_STANDARD_API(fork_function)
         else if (0 == strcmp(argv[4], "8k")) {
           sampling = 8000;
         }
-				else {
+        else {
 					sampling = atoi(argv[4]);
-				}
+        }
         if (!parse_ws_uri(channel, argv[2], &host[0], &path[0], &port, &sslFlags)) {
           switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "invalid websocket uri: %s\n", argv[2]);
         }
-				else if (sampling % 8000 != 0) {
+        else if (sampling % 8000 != 0) {
           switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "invalid sample rate: %s\n", argv[4]);					
-				}
+        }
         else {
          // create json string
             int channelCount = 1;
@@ -285,9 +285,7 @@ SWITCH_STANDARD_API(fork_function)
             cJSON_AddItemToObject(start, "mediaFormat", mediaFormat);
             cJSON_AddItemToObject(mediaFormat, "sampleRate", cJSON_CreateNumber(sampling));
             cJSON_AddItemToObject(mediaFormat, "channel", cJSON_CreateNumber(channelCount));
-            if (switch_true(switch_channel_get_variable(channel, "read_codec"))) {
-                codec = (char *)switch_channel_get_variable(channel, "read_codec");
-            }
+            codec = (char *)switch_channel_get_variable(channel, "read_codec");
             if(codec){
                 if ((0 == strcasecmp(codec, "PCMU")) || (0 == strcasecmp(codec, "PCMA"))){
                     cJSON_AddItemToObject(mediaFormat, "encoding", cJSON_CreateString("audio/x-pcm"));

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -5,6 +5,7 @@
  */
 #include "mod_audio_fork.h"
 #include "lws_glue.h"
+#include <string.h>
 
 //static int mod_running = 0;
 
@@ -16,6 +17,17 @@ SWITCH_MODULE_DEFINITION(mod_audio_fork, mod_audio_fork_load, mod_audio_fork_shu
 
 static void responseHandler(switch_core_session_t* session, const char * eventName, char * json) {
 	switch_event_t *event;
+    switch_status_t status = SWITCH_STATUS_FALSE;
+
+	// send mark event back
+	if (0 == strcmp(eventName, EVENT_MARK)){
+        status = send_text(session, json);
+        if (status == SWITCH_STATUS_SUCCESS) {
+            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "mark event success payload: %s.\n", json);
+        } else {
+            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Err sending mark event: %s \n", json);
+        }
+	}
 
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	if (json) switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "responseHandler: sending event payload: %s.\n", json);

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -208,7 +208,7 @@ SWITCH_STANDARD_API(fork_function)
       	char *uuidWithCID = argc > 7 ? argv[7]: NULL;
         char *track = argc > 8 ? argv[8] : NULL ;
         char *metadata = argc > 9 ? argv[9] : NULL ;
-        switch_channel_t *channel = switch_core_session_get_channel(lsession);
+        char *codec = NULL;
 
         if (0 == strcmp(argv[3], "mixed")) {
           flags |= SMBF_WRITE_STREAM ;
@@ -285,7 +285,9 @@ SWITCH_STANDARD_API(fork_function)
             cJSON_AddItemToObject(start, "mediaFormat", mediaFormat);
             cJSON_AddItemToObject(mediaFormat, "sampleRate", cJSON_CreateNumber(sampling));
             cJSON_AddItemToObject(mediaFormat, "channel", cJSON_CreateNumber(channelCount));
-            char *codec = switch_channel_get_variable(channel, "read_codec");
+            if (switch_true(switch_channel_get_variable(channel, "read_codec"))) {
+                codec = (char *)switch_channel_get_variable(channel, "read_codec");
+            }
             if(codec){
                 if ((0 == strcasecmp(codec, "PCMU")) || (0 == strcasecmp(codec, "PCMA"))){
                     cJSON_AddItemToObject(mediaFormat, "encoding", cJSON_CreateString("audio/x-pcm"));

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -153,10 +153,10 @@ static switch_status_t send_text(switch_core_session_t *session, char* text) {
   return status;
 }
 
-#define FORK_API_SYNTAX "<uuid> [start | stop | send_text | pause | resume | graceful-shutdown ] [wss-url | path] [mono | mixed | stereo] [8000 | 16000 | 24000 | 32000 | 64000] [streamID] [accID][metadata]"
+#define FORK_API_SYNTAX "<uuid> [start | stop | send_text | pause | resume | graceful-shutdown ] [wss-url | path] [mono | mixed | stereo] [8000 | 16000 | 24000 | 32000 | 64000] [streamID] [accID] [uuid_with_cid] [metadata]"
 SWITCH_STANDARD_API(fork_function)
 {
-	char *mycmd = NULL, *argv[8] = { 0 };
+	char *mycmd = NULL, *argv[9] = { 0 };
 	int argc = 0;
 	switch_status_t status = SWITCH_STATUS_FALSE;
 
@@ -205,7 +205,8 @@ SWITCH_STANDARD_API(fork_function)
       	switch_media_bug_flag_t flags = SMBF_READ_STREAM ;
       	char *streamID = argc > 5 ? argv[5] : NULL ;
       	char *accID = argc > 6 ? argv[6] : NULL ;
-        char *metadata = argc > 7 ? argv[7] : NULL ;
+      	char *uuidWithCID = argc > 7 ? argv[7]: NULL;
+        char *metadata = argc > 8 ? argv[8] : NULL ;
         if (0 == strcmp(argv[3], "mixed")) {
           flags |= SMBF_WRITE_STREAM ;
         }
@@ -246,13 +247,15 @@ SWITCH_STANDARD_API(fork_function)
             cJSON_AddItemToObject(obj, "sequenceNumber", cJSON_CreateNumber(1));
             cJSON_AddItemToObject(obj, "start", start);
 
-            cJSON_AddItemToObject(start, "callSid", cJSON_CreateString(argv[0]));
             if(streamID){
                 cJSON_AddItemToObject(obj, "streamSid", cJSON_CreateString(streamID));
                 cJSON_AddItemToObject(start, "streamSid", cJSON_CreateString(streamID));
             }
             if(accID){
                 cJSON_AddItemToObject(start, "accountSid", cJSON_CreateString(accID));
+            }
+            if(uuidWithCID){
+                cJSON_AddItemToObject(start, "callSid", cJSON_CreateString(uuidWithCID));
             }
             if(metadata){
                 custom = cJSON_Parse(metadata);
@@ -267,6 +270,8 @@ SWITCH_STANDARD_API(fork_function)
             out = cJSON_Print(obj);
 
             status = start_capture(lsession, flags, host, port, path, sampling, sslFlags, out, "mod_audio_fork");
+
+            cJSON_Delete(obj);
         }
 			}
       else {

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -202,7 +202,6 @@ SWITCH_STANDARD_API(fork_function)
         unsigned int port;
         int sslFlags;
         int sampling = 8000;
-        int channel = 1;
       	switch_media_bug_flag_t flags = SMBF_READ_STREAM ;
       	char *streamID = argc > 5 ? argv[5] : NULL ;
       	char *accID = argc > 6 ? argv[6] : NULL ;
@@ -238,6 +237,7 @@ SWITCH_STANDARD_API(fork_function)
 				}
         else {
          // create json string
+            int channel = 1;
             char *out;
             cJSON *obj, *start, *mediaFormat, *custom, *tracks;
             obj = cJSON_CreateObject();
@@ -271,12 +271,13 @@ SWITCH_STANDARD_API(fork_function)
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("outbound"));
                 }
                 else if (0 == strcmp(track, "outbound_track"){
-                    channel = 1;
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("outbound"));
                 }
-                else {
-                    channel = 1;
+                else if (0 == strcmp(track, "inbound_track"){
                     cJSON_AddItemToArray(tracks, cJSON_CreateString("inbound"));
+                }
+                else{
+                    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "invalid track value %s\n", track);
                 }
             }
             cJSON_AddItemToObject(start, "mediaFormat", mediaFormat);

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -15,9 +15,12 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_audio_fork_load);
 
 SWITCH_MODULE_DEFINITION(mod_audio_fork, mod_audio_fork_load, mod_audio_fork_shutdown, NULL /*mod_audio_fork_runtime*/);
 
+static switch_status_t send_text(switch_core_session_t *session, char* text);
+
 static void responseHandler(switch_core_session_t* session, const char * eventName, char * json) {
 	switch_event_t *event;
     switch_status_t status = SWITCH_STATUS_FALSE;
+    switch_channel_t *channel = switch_core_session_get_channel(session);
 
 	// send mark event back
 	if (0 == strcmp(eventName, EVENT_MARK)){
@@ -29,7 +32,6 @@ static void responseHandler(switch_core_session_t* session, const char * eventNa
         }
 	}
 
-	switch_channel_t *channel = switch_core_session_get_channel(session);
 	if (json) switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "responseHandler: sending event payload: %s.\n", json);
 	switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, eventName);
 	switch_channel_event_set_data(channel, event);

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -167,7 +167,7 @@ static switch_status_t send_text(switch_core_session_t *session, char* text) {
   return status;
 }
 
-#define FORK_API_SYNTAX "<uuid> [start | stop | send_text | pause | resume | graceful-shutdown ] [wss-url | path] [mono | mixed | stereo] [8000 | 16000 | 24000 | 32000 | 64000] [streamID] [accID] [uuidWithHash] [track] [metadata]"
+#define FORK_API_SYNTAX "<uuid> [start | stop | send_text | pause | resume | graceful-shutdown ] [wss-url | path] [mono | mixed | stereo] [8000 | 16000 | 24000 | 32000 | 64000] [streamID] [accID] [callSid] [track] [metadata]"
 SWITCH_STANDARD_API(fork_function)
 {
 	char *mycmd = NULL, *argv[10] = { 0 };
@@ -219,7 +219,7 @@ SWITCH_STANDARD_API(fork_function)
       	switch_media_bug_flag_t flags = SMBF_READ_STREAM ;
       	char *streamID = argc > 5 ? argv[5] : NULL ;
       	char *accID = argc > 6 ? argv[6] : NULL ;
-      	char *uuidWithCID = argc > 7 ? argv[7]: NULL;
+      	char *callSid = argc > 7 ? argv[7]: NULL;
         char *track = argc > 8 ? argv[8] : NULL ;
         char *metadata = argc > 9 ? argv[9] : NULL ;
         char *codec = NULL;
@@ -272,8 +272,8 @@ SWITCH_STANDARD_API(fork_function)
             if(accID){
                 cJSON_AddItemToObject(start, "accountSid", cJSON_CreateString(accID));
             }
-            if(uuidWithCID){
-                cJSON_AddItemToObject(start, "callSid", cJSON_CreateString(uuidWithCID));
+            if(callSid){
+                cJSON_AddItemToObject(start, "callSid", cJSON_CreateString(callSid));
             }
             if(metadata){
                 custom = cJSON_Parse(metadata);

--- a/modules/mod_audio_fork/mod_audio_fork.h
+++ b/modules/mod_audio_fork/mod_audio_fork.h
@@ -23,6 +23,7 @@
 #define EVENT_CONNECT_FAIL    "mod_audio_fork::connect_failed"
 #define EVENT_BUFFER_OVERRUN  "mod_audio_fork::buffer_overrun"
 #define EVENT_JSON            "mod_audio_fork::json"
+#define EVENT_MARK            "mod_audio_fork::mark"
 
 #define MAX_METADATA_LEN (8192)
 


### PR DESCRIPTION
Changes:
- Dynamic media encoding based on the call codec
- Track and channel count based on the command variable track
- UUIDWithHash as callSID value
- `event:"mark"` handler added 
- New Command:
```
uuid_audio_fork <uuid> start <wss-url> <mix-type> <sampling-rate> <streamID> <accID> <uuidWithHash> <track> <metadata>

```