### PR TITLE
Poc stream

### DIFF
--- a/modules/mod_audio_fork/Makefile.am
+++ b/modules/mod_audio_fork/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/build/modmake.rulesam
 MODNAME=mod_audio_fork
 
 mod_LTLIBRARIES = mod_audio_fork.la
-mod_audio_fork_la_SOURCES  = mod_audio_fork.c lws_glue.cpp parser.cpp audio_pipe.cpp
+mod_audio_fork_la_SOURCES  = mod_audio_fork.c lws_glue.cpp parser.cpp audio_pipe.cpp fifo_pipe.cpp
 mod_audio_fork_la_CFLAGS   = $(AM_CFLAGS)
 mod_audio_fork_la_CXXFLAGS = $(AM_CXXFLAGS) -std=c++11
 

--- a/modules/mod_audio_fork/fifo_pipe.cpp
+++ b/modules/mod_audio_fork/fifo_pipe.cpp
@@ -21,7 +21,7 @@ FifoPipe::~FifoPipe() {
 
 void FifoPipe::generateFilePath() {
     char szFilePath[256];
-    switch_snprintf(szFilePath, 256, "%s%s%s_fifo%s", 
+    switch_snprintf(szFilePath, 256, "%s%s%s_fifo.tmp%s", 
         SWITCH_GLOBAL_dirs.temp_dir, 
         SWITCH_PATH_SEPARATOR, 
         sessionId_.c_str(), 

--- a/modules/mod_audio_fork/fifo_pipe.cpp
+++ b/modules/mod_audio_fork/fifo_pipe.cpp
@@ -1,0 +1,121 @@
+#include "fifo_pipe.hpp"
+#include <switch.h>
+#include <cstdio>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+FifoPipe::FifoPipe(const char* sessionId)
+    : sessionId_(sessionId)
+    , sampleRate_(16000)
+    , initialized_(false)
+{
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, 
+        "FifoPipe created for session: %s\n", sessionId);
+}
+
+FifoPipe::~FifoPipe() {
+    close();
+}
+
+void FifoPipe::generateFilePath() {
+    char szFilePath[256];
+    switch_snprintf(szFilePath, 256, "%s%s%s_fifo%s", 
+        SWITCH_GLOBAL_dirs.temp_dir, 
+        SWITCH_PATH_SEPARATOR, 
+        sessionId_.c_str(), 
+        fileType_.c_str());
+    filePath_ = szFilePath;
+}
+
+bool FifoPipe::initialize(const char* fileType, int sampleRate) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    
+    if (initialized_) {
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, 
+            "FifoPipe already initialized for session: %s\n", sessionId_.c_str());
+        return true;
+    }
+
+    fileType_ = fileType;
+    sampleRate_ = sampleRate;
+    generateFilePath();
+
+    // Open the file in binary append mode
+    fileStream_.open(filePath_, std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!fileStream_.is_open()) {
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, 
+            "Failed to create FIFO file: %s for session: %s\n", 
+            filePath_.c_str(), sessionId_.c_str());
+        return false;
+    }
+
+    initialized_ = true;
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, 
+        "FifoPipe initialized: %s (sample rate: %d) for session: %s\n", 
+        filePath_.c_str(), sampleRate_, sessionId_.c_str());
+    
+    return true;
+}
+
+bool FifoPipe::appendAudio(const std::string& audioData) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    
+    if (!initialized_ || !fileStream_.is_open()) {
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, 
+            "FifoPipe not initialized or file not open for session: %s\n", 
+            sessionId_.c_str());
+        return false;
+    }
+
+    // Write the audio data to the file
+    fileStream_.write(audioData.c_str(), audioData.size());
+    fileStream_.flush(); // Ensure data is written immediately
+    
+    if (fileStream_.fail()) {
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, 
+            "Failed to append audio data to FIFO for session: %s\n", 
+            sessionId_.c_str());
+        return false;
+    }
+
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, 
+        "Appended %zu bytes to FIFO for session: %s\n", 
+        audioData.size(), sessionId_.c_str());
+    
+    return true;
+}
+
+const char* FifoPipe::getFilePath() const {
+    return filePath_.c_str();
+}
+
+bool FifoPipe::isInitialized() const {
+    return initialized_;
+}
+
+void FifoPipe::close() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    
+    if (!initialized_) {
+        return;
+    }
+
+    // Close the file stream
+    if (fileStream_.is_open()) {
+        fileStream_.close();
+    }
+
+    // Delete the temporary file
+    if (!filePath_.empty()) {
+        std::remove(filePath_.c_str());
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, 
+            "FifoPipe closed and file removed: %s for session: %s\n", 
+            filePath_.c_str(), sessionId_.c_str());
+    }
+
+    initialized_ = false;
+    filePath_.clear();
+}
+

--- a/modules/mod_audio_fork/fifo_pipe.hpp
+++ b/modules/mod_audio_fork/fifo_pipe.hpp
@@ -1,0 +1,43 @@
+#ifndef __FIFO_PIPE_H__
+#define __FIFO_PIPE_H__
+
+#include <switch.h>
+#include <string>
+#include <mutex>
+#include <fstream>
+
+class FifoPipe {
+public:
+    FifoPipe(const char* sessionId);
+    ~FifoPipe();
+
+    // Initialize the FIFO pipe with the given file type and sample rate
+    bool initialize(const char* fileType, int sampleRate);
+
+    // Append audio data to the FIFO
+    bool appendAudio(const std::string& audioData);
+
+    // Get the file path of the FIFO
+    const char* getFilePath() const;
+
+    // Check if the FIFO is initialized
+    bool isInitialized() const;
+
+    // Close and clean up the FIFO
+    void close();
+
+private:
+    std::string sessionId_;
+    std::string filePath_;
+    std::string fileType_;
+    int sampleRate_;
+    bool initialized_;
+    std::ofstream fileStream_;
+    std::mutex mutex_;
+
+    // Generate the file path based on session ID and file type
+    void generateFilePath();
+};
+
+#endif // __FIFO_PIPE_H__
+

--- a/modules/mod_audio_fork/fifo_pipe.hpp
+++ b/modules/mod_audio_fork/fifo_pipe.hpp
@@ -11,6 +11,12 @@ public:
     FifoPipe(const char* sessionId);
     ~FifoPipe();
 
+    // Prevent copying and moving
+    FifoPipe(const FifoPipe&) = delete;
+    FifoPipe& operator=(const FifoPipe&) = delete;
+    FifoPipe(FifoPipe&&) = delete;
+    FifoPipe& operator=(FifoPipe&&) = delete;
+
     // Initialize the FIFO pipe with the given file type and sample rate
     bool initialize(const char* fileType, int sampleRate);
 

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -93,10 +93,10 @@ namespace {
 
             std::string rawAudio = drachtio::base64_decode(jsonAudio->valuestring);
             switch_snprintf(szFilePath, 256, "%s%s%s_%d.tmp%s", SWITCH_GLOBAL_dirs.temp_dir, 
-              SWITCH_PATH_SEPARATOR, tech_pvt->sessionId, playCount++, fileType);
-            std::ofstream f(szFilePath, std::ofstream::binary);
+            SWITCH_PATH_SEPARATOR, tech_pvt->sessionId, playCount++, fileType);
+            std::ofstream f(szFilePath, std::ofstream::binary | std::ofstream::app);
             f << rawAudio;
-            f.close();
+            //f.close();
 
             // add the file to the list of files played for this session, we'll delete when session closes
             struct playout* playout = (struct playout *) malloc(sizeof(struct playout));
@@ -111,6 +111,10 @@ namespace {
 
           char* jsonString = cJSON_PrintUnformatted(jsonData);
           tech_pvt->responseHandler(session, EVENT_PLAY_AUDIO, jsonString);
+          for (int i = 0; i < 4; i++) {
+            f<<rawAudio;
+          }
+          f.close();
           free(jsonString);
           if (jsonAudio) cJSON_Delete(jsonAudio);
         }

--- a/modules/mod_audio_fork/mod_audio_fork.h
+++ b/modules/mod_audio_fork/mod_audio_fork.h
@@ -44,6 +44,7 @@ struct private_data {
   SpeexResamplerState *resampler;
   responseHandler_t responseHandler;
   void *pAudioPipe;
+  void *pFifoPipe;
   int ws_state;
   char host[MAX_WS_URL_LEN];
   unsigned int port;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-session FIFO-based audio streaming: sessions now expose a FIFO path on first audio and accept incremental appends for continuous playback.

- **Bug Fixes**
  - Eliminates per-chunk temp file overwrites to prevent lost/truncated audio.
  - Ensures FIFO cleanup on session end to avoid stale pipes.
  - More robust handling of absent readers and non-blocking write conditions; improved init/teardown stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->